### PR TITLE
Raise `ValidationError` for `#result` of unsuccessful `Outcome`

### DIFF
--- a/lib/formalism/form.rb
+++ b/lib/formalism/form.rb
@@ -2,6 +2,7 @@
 
 require_relative 'form/fields'
 require_relative 'form/outcome'
+require_relative 'form/validation_error'
 
 module Formalism
 	## Class for forms

--- a/lib/formalism/form/outcome.rb
+++ b/lib/formalism/form/outcome.rb
@@ -5,7 +5,7 @@ module Formalism
 	class Form < Action
 		## Private class for results
 		class Outcome
-			attr_reader :errors, :result
+			attr_reader :errors
 
 			def initialize(errors, result = nil)
 				@errors = errors
@@ -14,6 +14,12 @@ module Formalism
 
 			def success?
 				@errors.empty?
+			end
+
+			def result
+				raise ValidationError, errors if errors.any?
+
+				@result
 			end
 		end
 

--- a/lib/formalism/form/validation_error.rb
+++ b/lib/formalism/form/validation_error.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Formalism
+	class Form < Action
+		## When trying to get `#result` from unsuccessful outcome
+		class ValidationError < StandardError
+			attr_reader :errors
+
+			def initialize(errors)
+				@errors = errors
+				super "Outcome has errors: #{errors.to_a}"
+			end
+		end
+	end
+end

--- a/spec/formalism/form/validation_error_spec.rb
+++ b/spec/formalism/form/validation_error_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+describe Formalism::Form::ValidationError do
+	subject { described_class.new(errors) }
+
+	let(:errors) { ['Foo is incorrect', 'Bar is too low'] }
+
+	describe '#errors' do
+		subject { super().errors }
+
+		it { is_expected.to eq errors }
+	end
+
+	describe '#inspect' do
+		subject { super().message }
+
+		it { is_expected.to eq "Outcome has errors: #{errors}" }
+	end
+end

--- a/spec/formalism/form_spec.rb
+++ b/spec/formalism/form_spec.rb
@@ -640,7 +640,7 @@ describe Formalism::Form do
 		end
 
 		describe '#result' do
-			subject { form_run.result }
+			subject(:result) { form_run.result }
 
 			context 'with correct params' do
 				let(:params) { correct_album_params }
@@ -653,10 +653,18 @@ describe Formalism::Form do
 
 			context 'with incorrect params' do
 				let(:params) { incorrect_album_params }
-
-				it { is_expected.to be_nil }
+				let(:error_message) do
+					<<~MESSAGE.chomp
+						Outcome has errors: ["Album title is not present", "Album year is not in #{YEAR_RANGE}"]
+					MESSAGE
+				end
 
 				include_examples 'there are no Albums'
+
+				it do
+					expect { result }
+						.to raise_error Formalism::Form::ValidationError, error_message
+				end
 			end
 		end
 	end


### PR DESCRIPTION
/cc @JelF