### PR TITLE
Upgrade rubocop to version 0.66.0

### DIFF
--- a/formalism.gemspec
+++ b/formalism.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
 	s.add_development_dependency 'pry-byebug', '~> 3'
 	s.add_development_dependency 'rake', '~> 12'
 	s.add_development_dependency 'rspec', '~> 3'
-	s.add_development_dependency 'rubocop', '~> 0.59.0'
+	s.add_development_dependency 'rubocop', '~> 0.66.0'
 	s.add_development_dependency 'simplecov', '~> 0'
 end

--- a/spec/formalism/form/fields_spec.rb
+++ b/spec/formalism/form/fields_spec.rb
@@ -210,12 +210,7 @@ describe Formalism::Form::Fields do
 						field :foo, Symbol
 						field :status, Symbol
 
-						## https://github.com/rubocop-hq/rubocop/issues/5956
-						# rubocop:disable Layout/AccessModifierIndentation
-
 						private
-
-						# rubocop:enable Layout/AccessModifierIndentation
 
 						def status=(value)
 							super unless value == 'all'

--- a/spec/formalism/form_spec.rb
+++ b/spec/formalism/form_spec.rb
@@ -51,8 +51,6 @@ describe Formalism::Form do
 			'Album', Model.new(:title, :year, :artist, :tag, :label, :genre)
 		)
 
-		## https://github.com/bbatsov/rubocop/issues/5830
-		# rubocop:disable Layout/AccessModifierIndentation
 		stub_const(
 			'AlbumForm', Class.new(described_class) do
 				field :id, Integer, merge: false
@@ -74,7 +72,6 @@ describe Formalism::Form do
 				end
 			end
 		)
-		# rubocop:enable Layout/AccessModifierIndentation
 	end
 
 	describe '.field' do
@@ -513,8 +510,6 @@ describe Formalism::Form do
 				'Label', Model.new(:name)
 			)
 
-			## https://github.com/bbatsov/rubocop/issues/5830
-			# rubocop:disable Layout/AccessModifierIndentation
 			stub_const(
 				'ArtistForm', Class.new(described_class) do
 					attr_reader :artist
@@ -621,7 +616,6 @@ describe Formalism::Form do
 					end
 				end
 			)
-			# rubocop:enable Layout/AccessModifierIndentation
 		end
 
 		let(:album_with_nested_form) { AlbumWithNestedForm.new(params) }


### PR DESCRIPTION





Here is everything you need to know about this upgrade. Please take a good look at what changed and the test results before merging this pull request.

### What changed?


#### ✳️ rubocop (~> 0.59.0 → ~> 0.66.0) · [Repo](http://github.com/bbatsov/rubocop) · [Changelog](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md)

<details>
<summary>Release Notes</summary>
<h4><a href="https://github.com/rubocop-hq/rubocop/releases/tag/v0.66.0">0.66.0</a></h4>

<blockquote><h3>New features</h3>
<ul>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/issues/6393">#6393</a>: Add <code>AllowBracesOnProceduralOneLiners</code> option to fine-tune <code>Style/BlockDelimiter</code>'s semantic mode. (<a href="https://bounce.depfu.com/github.com/davearonson">@davearonson</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/issues/6383">#6383</a>: Add <code>AllowBeforeTrailingComments</code> option on <code>Layout/ExtraSpacing</code> cop. (<a href="https://bounce.depfu.com/github.com/davearonson">@davearonson</a>)</li>
<li>New cop <code>Lint/SafeNavigationWithEmpty</code> checks for <code>foo&amp;.empty?</code> in conditionals. (<a href="https://bounce.depfu.com/github.com/rspeicher">@rspeicher</a>)</li>
<li>Add new <code>Style/ConstantVisibility</code> cop for enforcing visibility declarations of class and module constants. (<a href="https://bounce.depfu.com/github.com/drenmi">@drenmi</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/issues/6378">#6378</a>: Add <code>Lint/ToJSON</code> cop to enforce an argument when overriding <code>#to_json</code>. (<a href="https://bounce.depfu.com/github.com/allcentury">@allcentury</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/issues/6346">#6346</a>: Add auto-correction to <code>Rails/TimeZone</code>. (<a href="https://bounce.depfu.com/github.com/dcluna">@dcluna</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/issues/6840">#6840</a>: Node patterns now allow unlimited elements after <code>...</code>. (<a href="https://bounce.depfu.com/github.com/marcandre">@marcandre</a>)</li>
</ul>
<h3>Bug fixes</h3>
<ul>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/pull/4321">#4321</a>: Fix false offense for <code>Style/RedundantSelf</code> when the method is also defined on <code>Kernel</code>. (<a href="https://bounce.depfu.com/github.com/mikegee">@mikegee</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/pull/6821">#6821</a>: Fix false negative for <code>Rails/LinkToBlank</code> when <code>_blank</code> is a symbol. (<a href="https://bounce.depfu.com/github.com/Intrepidd">@Intrepidd</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/issues/6699">#6699</a>: Fix infinite loop for <code>Layout/IndentationWidth</code> and <code>Layout/IndentationConsistency</code> when bad modifier indentation before good method definition. (<a href="https://bounce.depfu.com/github.com/koic">@koic</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/issues/6777">#6777</a>: Fix a false positive for <code>Style/TrivialAccessors</code> when using trivial reader/writer methods at the top level. (<a href="https://bounce.depfu.com/github.com/koic">@koic</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/pull/6799">#6799</a>: Fix errors for <code>Style/ConditionalAssignment</code>, <code>Style/IdenticalConditionalBranches</code>, <code>Lint/ElseLayout</code>, and <code>Layout/IndentationWidth</code> with empty braces. (<a href="https://bounce.depfu.com/github.com/pocke">@pocke</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/pull/6802">#6802</a>: Fix auto-correction for <code>Style/SymbolArray</code> with array contains interpolation when <code>EnforcedStyle</code> is <code>brackets</code>. (<a href="https://bounce.depfu.com/github.com/pocke">@pocke</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/pull/6797">#6797</a>: Fix false negative for Layout/SpaceAroundBlockParameters on block parameter with parens. (<a href="https://bounce.depfu.com/github.com/pocke">@pocke</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/pull/6798">#6798</a>: Fix infinite loop for <code>Layout/SpaceAroundBlockParameters</code> with <code>EnforcedStyleInsidePipes: :space</code>. (<a href="https://bounce.depfu.com/github.com/pocke">@pocke</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/pull/6803">#6803</a>: Fix error for <code>Style/NumericLiterals</code> on a literal that contains spaces. (<a href="https://bounce.depfu.com/github.com/pocke">@pocke</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/pull/6801">#6801</a>: Fix auto-correction for <code>Style/Lambda</code> with no-space argument. (<a href="https://bounce.depfu.com/github.com/pocke">@pocke</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/pull/6804">#6804</a>: Fix auto-correction of <code>Style/NumericLiterals</code> on numeric literal with exponent. (<a href="https://bounce.depfu.com/github.com/pocke">@pocke</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/issues/6800">#6800</a>: Fix an incorrect auto-correct for <code>Rails/Validation</code> when method arguments are enclosed in parentheses. (<a href="https://bounce.depfu.com/github.com/koic">@koic</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/issues/6808">#6808</a>: Prevent false positive in <code>Naming/ConstantName</code> when assigning a frozen range. (<a href="https://bounce.depfu.com/github.com/drenmi">@drenmi</a>)</li>
<li>Fix the calculation of <code>Metrics/AbcSize</code>. Comparison methods and <code>else</code> branches add to the comparison count. (<a href="https://bounce.depfu.com/github.com/rrosenblum">@rrosenblum</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/pull/6791">#6791</a>: Allow <code>Rails/ReflectionClassName</code> to use symbol argument for <code>class_name</code>. (<a href="https://bounce.depfu.com/github.com/unasuke">@unasuke</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/issues/5465">#5465</a>: Fix <code>Layout/ClassStructure</code> to allow grouping macros by their visibility. (<a href="https://bounce.depfu.com/github.com/gprado">@gprado</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/pull/6461">#6461</a>: Restrict <code>Ctrl-C</code> handling to RuboCop's loop and simplify it to a single phase. (<a href="https://bounce.depfu.com/github.com/deivid-rodriguez">@deivid-rodriguez</a>)</li>
</ul>
<h3>Changes</h3>
<ul>
<li>Add <code>$stdout</code>/<code>$stderr</code> and <code>STDOUT</code>/<code>STDERR</code> method calls to <code>Rails/Output</code>. (<a href="https://bounce.depfu.com/github.com/elebow">@elebow</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/pull/6688">#6688</a>: Add <code>iterator?</code> to deprecated methods and prefer <code>block_given?</code> instead. (<a href="https://bounce.depfu.com/github.com/tejasbubane">@tejasbubane</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/pull/6806">#6806</a>: Remove <code>powerpack</code> dependency. (<a href="https://bounce.depfu.com/github.com/dduugg">@dduugg</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/pull/6810">#6810</a>: Exclude gemspec file by default for <code>Metrics/BlockLength</code> cop. (<a href="https://bounce.depfu.com/github.com/koic">@koic</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/pull/6813">#6813</a>: Allow unicode/display_width dependency version 1.5.0. (<a href="https://bounce.depfu.com/github.com/tagliala">@tagliala</a>)</li>
<li>Make <code>Style/RedundantFreeze</code> aware of methods that will produce frozen objects. (<a href="https://bounce.depfu.com/github.com/rrosenblum">@rrosenblum</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/issues/6675">#6675</a>: Avoid printing deprecation warnings about constants. (<a href="https://bounce.depfu.com/github.com/elmasantos">@elmasantos</a>)</li>
<li>
<a href="https://bounce.depfu.com/github.com/rubocop-hq/rubocop/issues/6746">#6746</a>: Avoid offense on <code>$stderr.puts</code> with no arguments. (<a href="https://bounce.depfu.com/github.com/luciamo">@luciamo</a>)</li>
<li>Replace md5 with sha1 for FIPS compliance. (<a href="https://bounce.depfu.com/github.com/dirtyharrycallahan">@dirtyharrycallahan</a>)</li>
</ul></blockquote>
<p><em>Does any of this look wrong? <a href="https://depfu.com/packages/rubygem/rubocop/feedback">Please let us know.</a></em></p>
</details>

<details>
<summary>Commits</summary>
<p><a href="https://github.com/bbatsov/rubocop/compare/2e52af0e33cc6387f7c8495b52f66c8f2f46a804...2e96953c10be61f7255ebcbdc73ffccff5b2baef">See the full diff on Github</a>. The new version differs by more commits than we can show here.</p>
</details>





---
![Depfu Status](https://depfu.com/badges/896aa81c51bedc0740004884b4afe372/stats.svg)

[Depfu](https://depfu.com) will automatically keep this PR conflict-free, as long as you don't add any commits to this branch yourself. You can also trigger a rebase manually by commenting with `@depfu rebase`.

<details><summary>All Depfu comment commands</summary>
<blockquote><dl>
<dt>@​depfu rebase</dt><dd>Rebases against your default branch and redoes this update</dd>
<dt>@​depfu merge</dt><dd>Merges this PR once your tests are passing and conflicts are resolved</dd>
<dt>@​depfu reopen</dt><dd>Restores the branch and reopens this PR (if it's closed)</dd>
<dt>@​depfu pause</dt><dd>Ignores all future updates for this dependency and closes this PR</dd>
<dt>@​depfu pause [minor|major]</dt><dd>Ignores all future minor/major updates for this dependency and closes this PR</dd>
<dt>@​depfu resume</dt><dd>Future versions of this dependency will create PRs again (leaves this PR as is)</dd>
</dl></blockquote>
</details>

