### PR TITLE
Fix nested "proxy" forms

### DIFF
--- a/lib/formalism/form.rb
+++ b/lib/formalism/form.rb
@@ -81,7 +81,7 @@ module Formalism
 
 			default = options[:default]
 			form.instance_variable_set(
-				options[:instance_variable_name],
+				"@#{options[:instance_variable]}",
 				default.is_a?(Proc) ? instance_exec(&default) : default
 			)
 		end

--- a/lib/formalism/form/fields.rb
+++ b/lib/formalism/form/fields.rb
@@ -39,7 +39,6 @@ module Formalism
 					end
 
 					options[:instance_variable] ||= name
-					options[:instance_variable_name] = "@#{options[:instance_variable]}"
 					fields_and_nested_forms[name] = options.merge(form: form)
 
 					define_nested_form_methods(name)
@@ -110,15 +109,8 @@ module Formalism
 			end
 
 			def select_for_merging(type)
-				send(type).select do |name, value|
-					merge_option =
-						self.class.fields_and_nested_forms[name].fetch(:merge, true)
-
-					next merge_option unless type == :nested_forms
-
-					merge_option && value.instance_variable_defined?(
-						self.class.fields_and_nested_forms[name][:instance_variable_name]
-					)
+				send(type).select do |name, _value|
+					self.class.fields_and_nested_forms[name].fetch(:merge, true)
 				end
 			end
 		end

--- a/spec/formalism/form/fields_spec.rb
+++ b/spec/formalism/form/fields_spec.rb
@@ -44,8 +44,7 @@ describe Formalism::Form::Fields do
 				foo: { type: nil }, bar: { type: Integer },
 				inner: {
 					form: InnerForm,
-					instance_variable: :inner,
-					instance_variable_name: '@inner'
+					instance_variable: :inner
 				}
 			}
 		end


### PR DESCRIPTION
When there are checks by instance variable,
but form has no instance variable, just another nested form.