### PR TITLE
Add `@instance` variable, remove `:instance_variable` option

### DIFF
--- a/lib/formalism/form/fields.rb
+++ b/lib/formalism/form/fields.rb
@@ -38,7 +38,6 @@ module Formalism
 							'is not present'
 					end
 
-					options[:instance_variable] ||= name
 					fields_and_nested_forms[name] = options.merge(form: form)
 
 					define_nested_form_methods(name)
@@ -64,11 +63,7 @@ module Formalism
 					module_for_accessors.instance_exec do
 						define_method("#{name}_form") { nested_forms[name] }
 
-						define_method(name) do
-							nested_forms[name].public_send(
-								self.class.fields_and_nested_forms[name][:instance_variable]
-							)
-						end
+						define_method(name) { nested_forms[name].instance }
 					end
 				end
 

--- a/spec/formalism/form/fields_spec.rb
+++ b/spec/formalism/form/fields_spec.rb
@@ -6,12 +6,16 @@ describe Formalism::Form::Fields do
 	class InnerForm < Formalism::Form
 		field :name, String
 
-		attr_reader :inner
-
-		def initialize(*)
+		## https://github.com/rubocop-hq/rubocop-rspec/issues/750
+		# rubocop:disable RSpec/InstanceVariable
+		def initialize(*args)
 			super
-			@inner = Inner.new(fields_and_nested_forms)
+
+			return if defined?(@instance)
+
+			@instance = Inner.new(fields_and_nested_forms)
 		end
+		# rubocop:enable RSpec/InstanceVariable
 	end
 
 	module BaseModule
@@ -43,8 +47,7 @@ describe Formalism::Form::Fields do
 			{
 				foo: { type: nil }, bar: { type: Integer },
 				inner: {
-					form: InnerForm,
-					instance_variable: :inner
+					form: InnerForm
 				}
 			}
 		end
@@ -65,12 +68,16 @@ describe Formalism::Form::Fields do
 			class InnerWithDefaultForm < Formalism::Form
 				field :name
 
-				attr_reader :inner_with_default
-
-				def initialize(*)
+				## https://github.com/rubocop-hq/rubocop-rspec/issues/750
+				# rubocop:disable RSpec/InstanceVariable
+				def initialize(*args)
 					super
-					@inner_with_default = Inner.new(fields_and_nested_forms)
+
+					return if defined?(@instance)
+
+					@instance = Inner.new(fields_and_nested_forms)
 				end
+				# rubocop:enable RSpec/InstanceVariable
 			end
 
 			module ModuleWithDefaults


### PR DESCRIPTION
Now if (even nested) form initialized via instance —
fields and nested forms will be also filled
(and validation will be successful).